### PR TITLE
Fix parsing description for zh_CN

### DIFF
--- a/game.libretro.gw/addon.xml.in
+++ b/game.libretro.gw/addon.xml.in
@@ -26,6 +26,6 @@
 		<summary lang="en_GB">Handheld Electronic (GW) 1.6.3</summary>
 		<description lang="en_GB">GW is a Game &amp; Watch simulator.</description>
 		<description lang="ko_KR">GW는 게임 &amp; 시계 시뮬레이터입니다.</description>
-		<description lang="zh_CN">GW 是一款 Game & Watch 模拟器。</description>
+		<description lang="zh_CN">GW 是一款 Game &amp; Watch 模拟器。</description>
 	</extension>
 </addon>


### PR DESCRIPTION
Error was:

```
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 29, column 41
```

Related PRs:

https://github.com/kodi-game/kodi-game-scripting/pull/99